### PR TITLE
Add Copilot doc generation toolkit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Copilot – Instruções Globais (documentação externa)
+Você é um redator técnico. SEMPRE produza documentação no formato abaixo, em PT-BR.
+
+### Título:
+<um título curto e claro>
+
+### Descrição:
+<parágrafo explicando o que o script/função faz e por quê>
+
+### Entradas:
+- `<nome>` (`<tipo>`): <descrição>
+- ...
+
+### Saídas:
+- `<tipo>`: <descrição>
+
+### Fluxo de Execução:
+1. ...
+2. ...
+3. ...
+
+### Dependências:
+- <biblioteca/versão>, ...
+
+### Erros Comuns:
+- <erro>: <causa> / <como resolver>
+
+### Exemplo de Uso:
+```bash
+<comando ou snippet>
+```

--- a/.github/prompts/docgen.prompt.md
+++ b/.github/prompts/docgen.prompt.md
@@ -1,0 +1,3 @@
+description: "Gerar documentação externa (Word) de código selecionado"
+Analise o código SELECIONADO no editor e gere a documentação **no exato formato** definido em `.github/copilot-instructions.md`. 
+Se faltarem detalhes no código, faça suposições mínimas e marque como "Assunção".

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.docx
+__pycache__/

--- a/.vscode/keybindings.json
+++ b/.vscode/keybindings.json
@@ -1,0 +1,8 @@
+[
+  {
+    "key": "ctrl+alt+w",
+    "command": "workbench.action.tasks.runTask",
+    "args": "Doc: gerar Word do script atual",
+    "when": "editorTextFocus"
+  }
+]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Doc: gerar Word do script atual",
+      "type": "shell",
+      "command": "python",
+      "args": [
+        "doc_to_word.py",
+        "--md",
+        "${workspaceFolder}/saida_copilot.md",
+        "--src",
+        "${file}",
+        "--template",
+        "${workspaceFolder}/template.docx",
+        "--out",
+        "${workspaceFolder}/docs/${fileBasenameNoExtension}.docx"
+      ],
+      "problemMatcher": [],
+      "group": "build"
+    }
+  ]
+}

--- a/doc_to_word.py
+++ b/doc_to_word.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Transforma a saída estruturada do Copilot (Markdown) + código-fonte
+em um documento Word (.docx) estilizado a partir de um template.
+
+Uso:
+  python doc_to_word.py --md saida_copilot.md --src caminho/do/script.py \
+                        --template template.docx --out docs/MeuScript.docx
+"""
+from __future__ import annotations
+import re
+from pathlib import Path
+from typing import Optional, Dict
+
+import typer
+from rich import print
+from docx import Document
+from docx.enum.text import WD_BREAK
+from docx.shared import Pt
+
+app = typer.Typer(add_completion=False)
+
+SECTION_KEYS = [
+    "Título", "Descrição", "Entradas", "Saídas",
+    "Fluxo de Execução", "Dependências", "Erros Comuns", "Exemplo de Uso"
+]
+
+def read_text(p: Path) -> str:
+    return p.read_text(encoding="utf-8", errors="ignore")
+
+def split_sections(md_text: str) -> Dict[str, str]:
+    """
+    Espera blocos '### <Seção>:' conforme instruções globais.
+    Retorna dict {secao: conteudo}.
+    """
+    # normaliza \r\n
+    t = md_text.replace("\r\n", "\n")
+    # pega tudo a partir do primeiro ### 
+    chunks = re.split(r"\n?###\s+", t)
+    sections: Dict[str, str] = {}
+    for ch in chunks:
+        if not ch.strip():
+            continue
+        # esperado: "Título:\nconteúdo..."
+        m = re.match(r"([^:\n]+):\s*\n(.*)", ch, flags=re.S)
+        if not m:
+            # tolera linha única "Título: algo" também
+            m = re.match(r"([^:\n]+):\s*(.*)", ch, flags=re.S)
+        if m:
+            key = m.group(1).strip()
+            val = (m.group(2) or "").strip()
+            sections[key] = val
+    return sections
+
+def add_code_block(doc: Document, text: str, style_name: str = "CodeBlock"):
+    """
+    Insere bloco de código (texto preservando quebras).
+    Usa estilo 'CodeBlock' se existir; senão, usa estilo normal.
+    """
+    # tenta estilo; se não existir, cai no normal
+    try:
+        _ = doc.styles[style_name]
+        has_style = True
+    except KeyError:
+        has_style = False
+
+    lines = text.replace("\r\n", "\n").split("\n")
+    for i, line in enumerate(lines):
+        p = doc.add_paragraph()
+        if has_style:
+            p.style = style_name
+        run = p.add_run(line if line else " ")
+        if i < len(lines) - 1:
+            run.add_break(WD_BREAK.LINE)
+
+def extract_fenced_code(md: str) -> Optional[str]:
+    """
+    Retorna o primeiro bloco de código com fences ```...```.
+    """
+    m = re.search(r"```[^\n]*\n(.*?)```", md, flags=re.S)
+    return m.group(1).rstrip("\n") if m else None
+
+@app.command()
+def build(
+    md: Path = typer.Option(..., help="Arquivo .md com a saída do Copilot"),
+    src: Path = typer.Option(..., help="Arquivo de código-fonte relacionado"),
+    template: Path = typer.Option(..., help="Modelo do Word (.docx) com estilos"),
+    out: Path = typer.Option(..., help="Caminho do .docx de saída"),
+    include_source: bool = typer.Option(True, help="Incluir código-fonte completo no final"),
+):
+    if not md.exists():
+        raise typer.BadParameter(f"MD não encontrado: {md}")
+    if not src.exists():
+        raise typer.BadParameter(f"Fonte não encontrada: {src}")
+    if not template.exists():
+        raise typer.BadParameter(f"Template não encontrado: {template}")
+
+    md_text = read_text(md)
+    sections = split_sections(md_text)
+    code_from_md = extract_fenced_code(md_text)
+    source_code = read_text(src)
+
+    doc = Document(str(template))
+
+    # Título
+    title = sections.get("Título") or src.name
+    try:
+        doc.add_paragraph(title).style = "DocTitle"
+    except Exception:
+        doc.add_heading(title, level=1)
+
+    # Seções na ordem predefinida
+    for key in SECTION_KEYS:
+        content = sections.get(key)
+        if not content:
+            continue
+        # Cabeçalho
+        doc.add_heading(key, level=2)
+        # Conteúdo: tenta detectar lista vs bloco normal
+        if key in {"Entradas", "Saídas", "Dependências", "Erros Comuns"}:
+            # Quebra por linhas que começam com "- "
+            items = [ln[2:].strip() for ln in content.splitlines() if ln.strip().startswith("- ")]
+            if items:
+                for it in items:
+                    p = doc.add_paragraph(style="List Paragraph")
+                    p.add_run("• ").bold = True
+                    p.add_run(it)
+            else:
+                doc.add_paragraph(content, style="NormalText")
+        elif key == "Exemplo de Uso" and extract_fenced_code(content):
+            add_code_block(doc, extract_fenced_code(content) or "", style_name="CodeBlock")
+        else:
+            doc.add_paragraph(content, style="NormalText")
+
+    # Se houver código no bloco do exemplo e ainda não inserimos:
+    if "Exemplo de Uso" in sections and not extract_fenced_code(sections["Exemplo de Uso"]) and code_from_md:
+        doc.add_heading("Exemplo de Uso", level=2)
+        add_code_block(doc, code_from_md, style_name="CodeBlock")
+
+    # Anexar código-fonte completo (opcional)
+    if include_source:
+        doc.add_heading("Código-Fonte (Anexo)", level=2)
+        add_code_block(doc, source_code, style_name="CodeBlock")
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(str(out))
+    print(f"[green]OK[/green] Documento gerado em: [bold]{out}[/bold]")
+
+if __name__ == "__main__":
+    app()

--- a/saida_copilot.md
+++ b/saida_copilot.md
@@ -1,0 +1,3 @@
+# Saída do Copilot
+
+Substitua este conteúdo pela documentação gerada pelo Copilot.


### PR DESCRIPTION
## Summary
- Add global Copilot instructions for standardized Portuguese documentation
- Provide docgen prompt for VS Code Copilot Chat
- Implement `doc_to_word.py` to convert Copilot markdown and source code into styled Word docs
- Configure VS Code tasks and keybinding to run the converter
- Include placeholder `saida_copilot.md`
- Remove binary Word template and ignore future `.docx` artifacts

## Testing
- `python -m py_compile doc_to_word.py`
- `python doc_to_word.py --help`
- `python doc_to_word.py --md saida_copilot.md --src doc_to_word.py --template template_temp.docx --out docs/test.docx`


------
https://chatgpt.com/codex/tasks/task_e_68b87ea5ba4c8324aa65475a5851bfb4